### PR TITLE
Update bcwc_pcie-9999.ebuild to use master 

### DIFF
--- a/media-video/bcwc_pcie/bcwc_pcie-9999.ebuild
+++ b/media-video/bcwc_pcie/bcwc_pcie-9999.ebuild
@@ -27,7 +27,7 @@ CONFIG_CHECK="VIDEO_V4L2 VIDEOBUF2_CORE VIDEOBUF2_DMA_SG"
 
 src_unpack() {
 	kernel_is -ge 4 8 && {
-		EGIT_BRANCH="mainline"
+		EGIT_BRANCH="master"
 	}
 	git-r3_src_unpack
 }


### PR DESCRIPTION
See https://github.com/toaster/gentoo-overlay/issues/12 and https://github.com/patjak/bcwc_pcie/issues/197